### PR TITLE
Prev year question papers for Chemistry(CHIR11) of Civil First Semester are added

### DIFF
--- a/docs/Civil/First Year/Sem1.md
+++ b/docs/Civil/First Year/Sem1.md
@@ -38,9 +38,9 @@ Welcome to semester 1.
 ### CHIR11-Chemistry
 
 - Question Papers:<br/>
-  [CT-1](https://tecos-nit-trichy.github.io/painitte/blog#how-do-i-make-a-contribution-) &nbsp; | &nbsp;
-  [CT-2](https://tecos-nit-trichy.github.io/painitte/blog#how-do-i-make-a-contribution-) &nbsp; | &nbsp;
-  [End sem](https://tecos-nit-trichy.github.io/painitte/blog#how-do-i-make-a-contribution-)
+  [CT-1](https://drive.google.com/drive/folders/12TOLspFCP_QYc--V2v6vE51OxUvmrsR6?usp=share_link) &nbsp; | &nbsp;
+  [CT-2](https://drive.google.com/drive/folders/1h1cBQlTDeaFl8bQtnbAuyfQxPzA05J66?usp=share_link) &nbsp; | &nbsp;
+  [End sem](https://drive.google.com/drive/folders/10bicU1NaSQ2c0lEfQS8H_Dlv5u9R20ct?usp=share_link)
 - Resources:<br/>
   To be added
 


### PR DESCRIPTION

CT1, CT2 and End Sem papers for CHIR11 of Semester 1 for Civil Dept. are added using drive link.
When clicked to the CT1, it will redirect to the related folder of drive and student can access the papers. 